### PR TITLE
changes to be able to select the compression type

### DIFF
--- a/panel.html
+++ b/panel.html
@@ -200,7 +200,16 @@
         <option value="local">Local Storage</option>
         <option value="session">Session Storage</option>
     </select>
+    <select id="compressionType">
+        <option value="utf-16">UTF-16 (safe)</option>
+        <option value="utf-16_unsafe">UTF-16 (unsafe)</option>
+        <option value="base64">Base64</option>
+        <option value="uriSafe">URL Encoded</option>
+        <!-- <option value="uint-8">UInt8 Array</option> -->
+    </select>
     <span>Compressed files shown in <span class="compressed">red</span>.</span>
+
+
     <div id="sizeInfo">
         Compressed Size: <span id="compressedSize"></span>
         Uncompressed Size: <span id="uncompressedSize"></span>


### PR DESCRIPTION
It gets the job done but it isn't particularly elegant

* Added a select element with different options in panel.html
* panel.js detects changes on the select element and sets a flag so that all future decodes are done with the selected compression type

Currently it just caches the data from localStorage so that on select of the compression type it can be immediately re-evaluated but it might be better to not cache it and send a message to the window context to get a fresh set of data. Then it is one less global in the scope of panel.js